### PR TITLE
Update header for compilation

### DIFF
--- a/Source/Private/Widgets/SObjectBrowser.cpp
+++ b/Source/Private/Widgets/SObjectBrowser.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
 
+#include "ObjectBrowserModule.h"
 #include "SObjectBrowser.h"
 #include "SObjectBrowserTableRow.h"
 #include "PropertyEditorModule.h"


### PR DESCRIPTION
Fixing compilation problem by adding the module header to SObjectBrowser.cpp , used with 4.16.